### PR TITLE
Add more functionality to Question and Answer components, fixed bug in AnswersList

### DIFF
--- a/client/src/components/QA/AnswerForm.jsx
+++ b/client/src/components/QA/AnswerForm.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import axios from 'axios';
+import { useState, useEffect } from 'react';
+import * as styles from './qanda.module.css';
+
+function AnswerForm({product_id, question}) {
+  // this should be rendered in a new window
+  // axios GET for product_name
+  const product_name = 'product name'
+  return (
+    <div>
+      <h3>Submit your Answer</h3>
+      <h5>{product_name}: {question.question_body}</h5>
+      <div>
+        <label>Your Answer: </label>
+        <input placeholder="Your Answer"></input>
+      </div>
+      <div>
+        <label>What is your nickname: </label>
+        <input placeholder="Example: jack543!"></input>
+      </div>
+      <p>For privacy reasons, do not use your full name or email address</p>
+      <div>
+        <label>Your email: </label>
+        <input placeholder="Example: jack@email.com"></input>
+      </div>
+      <p>For authentication reasons, you will not be emailed</p>
+      <input type="button" value="Add photos"></input>
+    </div>
+  )
+}
+
+export default AnswerForm;

--- a/client/src/components/QA/AnswersList.jsx
+++ b/client/src/components/QA/AnswersList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import { useState, useEffect } from 'react';
 import Answer from './Answer.jsx';
+import * as styles from './qanda.module.css';
 
 function AnswersList({ question_id }) {
   const [answers, setAnswers] = useState([]);
@@ -43,10 +44,16 @@ function AnswersList({ question_id }) {
     setPage(1);
   }
   return (
-    <div>A:
-      {answers.map((answer) => <Answer key={answer.answer_id} answer={answer} />)}
-      { gotAll ? (<input type="button" value="Collapse" onClick={collapseAnswers} />) : (<input type="button" value="Load More Answers" onClick={loadMoreAnswers} />)}
+    <div className={styles.answersList}>
+      <div>
+        <strong>A:</strong>
+      </div>
+      <div>
+        {answers.map((answer) => <Answer key={answer.answer_id} answer={answer} />)}
+        { gotAll ? (<input type="button" value="Collapse" onClick={collapseAnswers} />) : (<input type="button" value="Load More Answers" onClick={loadMoreAnswers} />)}
+      </div>
     </div>
+
   );
 }
 export default AnswersList;

--- a/client/src/components/QA/AnswersList.jsx
+++ b/client/src/components/QA/AnswersList.jsx
@@ -10,7 +10,7 @@ function AnswersList({ question_id }) {
   const [page, setPage] = useState(1);
   useEffect(() => {
     if (!gotAll) {
-      axios.get(`/qa/questions/${question_id}/answers`, { params: { page: page.toString() } })
+      axios.get(`/qa/questions/${question_id}/answers`, { params: { page: page.toString(), count: '2'}})
         .then((response) => {
           // console.log('added up to 2 answers for Q', question_id, ':', response.data.results);
           if (response.data.results.length === 0) {
@@ -24,7 +24,7 @@ function AnswersList({ question_id }) {
           throw new Error(err);
         });
     } else {
-      axios.get(`/qa/questions/${question_id}/answers`, { params: { page: page.toString() } })
+      axios.get(`/qa/questions/${question_id}/answers`, { params: { page: page.toString(), count: '2'} })
         .then((response) => {
           // console.log('collapsed answers for Q', question_id, ':', response.data.results);
           setAnswers(response.data.results);

--- a/client/src/components/QA/Question.jsx
+++ b/client/src/components/QA/Question.jsx
@@ -40,7 +40,7 @@ function Question({ product_id, question }) {
           </span>
         </div>
       </div>
-      <AnswerForm product_id={product_id} question={question}/>
+      {/* <AnswerForm product_id={product_id} question={question}/> */}
       <AnswersList key={`answers_${question.question_id}`} question_id={question.question_id}/>
     </div>
   );

--- a/client/src/components/QA/Question.jsx
+++ b/client/src/components/QA/Question.jsx
@@ -1,15 +1,43 @@
 import React from 'react';
 import axios from 'axios';
+import { useState } from 'react';
 import AnswersList from './AnswersList.jsx';
+import * as styles from './qanda.module.css';
 
 function Question({ question }) {
   // given the question as a prop, find all answers associated with that question, sorted
   // sort first by seller, then by helpfulness without upending seller answers
+  const [isHelpful, setIsHelpful] = useState(false);
+  const [helpfulness, setHelpfulness] = useState(question.question_helpfulness);
+  function helpfulHandler() {
+    if (!isHelpful) {
+      setIsHelpful(true);
+      axios.put(`/qa/questions/${question.question_id}/helpful`)
+        .then(() => {
+          setHelpfulness(helpfulness + 1);
+        });
+    }
+  }
 
   return (
     <div>
-      <div>
-        {`Q: ${question.question_body}`}
+      <div className={styles.question}>
+        <div>
+          <strong>{`Q: ${question.question_body}`} </strong>
+        </div>
+        <div>
+          {'Helpful? '}
+          <span>
+            <a onClick={helpfulHandler}>Yes</a>
+          </span>
+          <span>
+            {` (${helpfulness})`}
+          </span>
+          <span>
+            {' | '}
+            <a href='/'>Add Answer</a>
+          </span>
+        </div>
       </div>
       <AnswersList key={`answers_${question.question_id}`} question_id={question.question_id}/>
     </div>

--- a/client/src/components/QA/Question.jsx
+++ b/client/src/components/QA/Question.jsx
@@ -3,8 +3,9 @@ import axios from 'axios';
 import { useState } from 'react';
 import AnswersList from './AnswersList.jsx';
 import * as styles from './qanda.module.css';
+import AnswerForm from './AnswerForm.jsx';
 
-function Question({ question }) {
+function Question({ product_id, question }) {
   // given the question as a prop, find all answers associated with that question, sorted
   // sort first by seller, then by helpfulness without upending seller answers
   const [isHelpful, setIsHelpful] = useState(false);
@@ -35,10 +36,11 @@ function Question({ question }) {
           </span>
           <span>
             {' | '}
-            <a href='/'>Add Answer</a>
+            <a href='/' target='_blank'>Add Answer</a>
           </span>
         </div>
       </div>
+      <AnswerForm product_id={product_id} question={question}/>
       <AnswersList key={`answers_${question.question_id}`} question_id={question.question_id}/>
     </div>
   );

--- a/client/src/components/QA/index.jsx
+++ b/client/src/components/QA/index.jsx
@@ -6,6 +6,7 @@ import Question from './Question.jsx';
 function QA({currentProductId}) {
   const [questions, setQuestions] = useState([]);
   const product_id = '37313';
+  //const product_id = '40347';
   useEffect(() => {
     axios.get('/qa/questions', { params: { product_id: product_id } })
       .then((response) => {
@@ -19,7 +20,6 @@ function QA({currentProductId}) {
 
   return (
     <div>
-      <strong>Q & A Module</strong>
       {questions.map((question) => (<Question key={question.question_id} question={question} />))}
     </div>
   );

--- a/client/src/components/QA/index.jsx
+++ b/client/src/components/QA/index.jsx
@@ -8,7 +8,7 @@ function QA({currentProductId}) {
   const product_id = '37313';
   //const product_id = '40347';
   useEffect(() => {
-    axios.get('/qa/questions', { params: { product_id: product_id } })
+    axios.get('/qa/questions', { params: { product_id: product_id }})
       .then((response) => {
         console.log('QUESTIONS FOR PRODUCT', product_id, response.data.results);
         setQuestions(response.data.results);

--- a/client/src/components/QA/index.jsx
+++ b/client/src/components/QA/index.jsx
@@ -20,7 +20,7 @@ function QA({currentProductId}) {
 
   return (
     <div>
-      {questions.map((question) => (<Question key={question.question_id} question={question} />))}
+      {questions.map((question) => (<Question key={question.question_id} product_id={product_id} question={question} />))}
     </div>
   );
 }

--- a/client/src/components/QA/qanda.module.css
+++ b/client/src/components/QA/qanda.module.css
@@ -5,3 +5,10 @@
 .answerDetails {
   color: gray;
 }
+.question {
+  display: flex;
+  justify-content: space-between;
+}
+.answersList {
+  display: flex;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^17.2.1",
         "express": "^4.17.1",
         "jest": "^30.0.5",
+        "lodash": "^4.17.21",
         "path": "^0.12.7",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -7462,6 +7463,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",


### PR DESCRIPTION
Clicking Yes on a question will send out a PATCH request and increase the helpfulness count ONCE unless page is refreshed.
Not sure how we are supposed to know if it's the same customer upon refresh but I am not handling it right now.

Stubbed out some pieces of the eventual Answer Form module.

From the BRD: _"Through the link provided on each question within the Questions list, users will be allowed to submit an answer for the product. Upon clicking the button a modal window should open, overlaying the product page."_
As of now, the static form is always rendered under each question. This commit does not make any axios POST requests yet.

I forgot to add in a default `count` param of 2 when merging in my AnswersList code from the other repo. The change I made isn't visible because there are only 2 answers max for the questions, but with more answers it should now load 2 more answers per button click, and then collapse down to 2 on button click once all possible answers are rendered.