### PR TITLE
fix: updated eslint rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+# Re-include only client/src
+!client/
+client/*
+!client/src/
+client/src/*
+!client/src/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   extends: ["airbnb", "airbnb/hooks", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
   env: { browser: true, es2021: true },
-  settings: { 
+  settings: {
     react: { version: "detect" },
     "import/resolver": { node: { extensions: [".js", ".jsx"] } }
   },
@@ -13,7 +13,6 @@ module.exports = {
       env: { browser: true, node: false },
       rules: {
         "no-console": ["warn", { allow: ["warn", "error", "debug"] }],
-        "react/react-in-jsx-scope": "off",
         "react/prop-types": "off",
         "jsx-quotes": ["error", "prefer-single"],
       }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,22 @@
 module.exports = {
-  extends: [
-    'airbnb',
-    'airbnb/hooks',
-    'plugin:react/recommended',
-    'plugin:jsx-a11y/recommended',
-  ],
-  env: {
-    browser: true,
-    es2021: true,
+  root: true,
+  extends: ["airbnb", "airbnb/hooks", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
+  env: { browser: true, es2021: true },
+  settings: { 
+    react: { version: "detect" },
+    "import/resolver": { node: { extensions: [".js", ".jsx"] } }
   },
-  settings: {
-    react: { version: 'detect' },
-  },
+  parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+  overrides: [
+    {
+      files: ["client/src/**/*.{js,jsx}"],
+      env: { browser: true, node: false },
+      rules: {
+        "no-console": ["warn", { allow: ["warn", "error", "debug"] }],
+        "react/react-in-jsx-scope": "off",
+        "react/prop-types": "off",
+        "jsx-quotes": ["error", "prefer-single"],
+      }
+    }
+  ]
 };

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Gallery, Info } from './components';
-import { getSkus, getQtys } from './lib/helpers.js';
-import * as g from '../global.module.css';
 import axios from 'axios';
+import Gallery from './components/Gallery';
+import Info from './components/Info';
+import * as g from '../global.module.css';
 
-function Overview({productId}) {
+function Overview({ productId }) {
   const [product, setProduct] = useState(null);
   const [styles, setStyles] = useState(null);
   const [selectedStyle, setSelectedStyle] = useState(0);
@@ -12,15 +12,15 @@ function Overview({productId}) {
 
   useEffect(() => {
     axios.get(`/products/${productId}`)
-         .then(res => {setProduct(res.data); return res.data;})
-        //  .then(res => console.log('product: ', res))
-         .catch(err => console.log('failed to get product by id', err));
+      .then((res) => { setProduct(res.data); return res.data; })
+      //  .then(res => console.log('product: ', res))
+      .catch((err) => console.error('failed to get product by id', err));
 
     axios.get(`/products/${productId}/styles`)
-         .then(res => {setStyles(res.data.results); return res.data.results;})
-        //  .then(res => console.log('styles: ', res))
-         .catch(err => console.log('failed to get styles by id', err));
-  }, [])
+      .then((res) => { setStyles(res.data.results); return res.data.results; })
+      //  .then(res => console.log('styles: ', res))
+      .catch((err) => console.error('failed to get styles by id', err));
+  }, [productId]);
 
   if (styles === null || product === null) {
     return (<div>loading...</div>);
@@ -44,7 +44,7 @@ function Overview({productId}) {
         />
       </div>
     </section>
-  )
+  );
 }
 
 export default Overview;

--- a/client/src/components/overview/components/CartForm.jsx
+++ b/client/src/components/overview/components/CartForm.jsx
@@ -16,7 +16,7 @@ function CartForm({
 }) {
   return (
     <>
-      <div className={`${g.group} ${css.gap}`}>
+      <div className={`${g.group} ${css.gap} ${g.fullWidth}`}>
         <Select
           className={css.fill}
           options={getSkus(styles[selectedStyle]).map((sku) => (

--- a/client/src/components/overview/components/CartForm.jsx
+++ b/client/src/components/overview/components/CartForm.jsx
@@ -1,38 +1,38 @@
-import React, { useState, useEffect } from 'react';
-import { Select } from '../components';
-import { getSkus, getQtys } from '../lib/helpers.js';
+import React from 'react';
 import { Plus } from '@phosphor-icons/react';
+import Select from './Select';
+import { getSkus, getQtys } from '../lib/helpers';
 import * as g from '../../global.module.css';
 import * as css from '../styles/cart_form.module.css';
 
 function CartForm({
   styles,
   selectedStyle,
-  setSku,
+  setSkuId,
   setQty,
-  sku,
+  skuId,
   qty,
-  postToCart
+  postToCart,
 }) {
   return (
     <>
       <div className={`${g.group} ${css.gap}`}>
         <Select
           className={css.fill}
-          options={getSkus(styles[selectedStyle]).map(sku => (
+          options={getSkus(styles[selectedStyle]).map((sku) => (
             {
               label: styles[selectedStyle].skus[sku].size,
-              value: sku
+              value: sku,
             }
           ))}
-          onChange={(value) => setSku(value)}
-          value={sku}
+          onChange={(value) => setSkuId(value)}
+          value={skuId}
         />
         <Select
-          options={getQtys(styles[selectedStyle], sku).map(amount => (
+          options={getQtys(styles[selectedStyle], skuId).map((amount) => (
             {
               label: amount,
-              value: amount
+              value: amount,
             }
           ))}
           onChange={(value) => setQty(value)}
@@ -41,15 +41,16 @@ function CartForm({
       </div>
       <div className={`${g.group} ${css.gap}`}>
         <button
+          type='submit'
           className={`${g.center} ${g.sb} ${css.fill}`}
           onClick={postToCart}
         >
           Add to bag
-          <Plus size={15}/>
+          <Plus size={15} />
         </button>
       </div>
     </>
-  )
+  );
 }
 
 export default CartForm;

--- a/client/src/components/overview/components/Gallery.jsx
+++ b/client/src/components/overview/components/Gallery.jsx
@@ -1,32 +1,31 @@
-import React, { useState, useEffect } from 'react';
-import { Thumbnail } from '../components';
-import Image from '../../shared/Image.jsx';
 import { CornersOut, ArrowLeft, ArrowRight } from '@phosphor-icons/react';
+import React, { useState, useEffect } from 'react';
+import Thumbnail from './Thumbnail';
+import Image from '../../shared/Image';
 import * as g from '../../global.module.css';
 import * as css from '../styles/gallery.module.css';
 
 function Gallery({
-  product,
   styles,
   selectedStyle,
-  isFullScreen,
-  setIsFullScreen
+  setIsFullScreen,
 }) {
   const [selectedImage, setSelectedImage] = useState(0);
   const [displayImage, setDisplayImage] = useState(styles[selectedStyle].photos[selectedImage].url);
 
   useEffect(() => {
-    setDisplayImage(styles[selectedStyle].photos[selectedImage].url)
-  }, [selectedImage, selectedStyle])
+    setDisplayImage(styles[selectedStyle].photos[selectedImage].url);
+  }, [selectedImage, selectedStyle, styles]);
 
   const handleArrows = (direction) => {
     if (direction === 'next' && selectedImage !== styles[selectedStyle].photos.length - 1) {
-      setSelectedImage(prev => prev + 1);
+      setSelectedImage((prev) => prev + 1);
     }
     if (direction === 'prev' && selectedImage !== 0) {
-      setSelectedImage(prev => prev - 1);
+      setSelectedImage((prev) => prev - 1);
     }
-  }
+  };
+
   return (
     <div className={css.galleryWrapper}>
       <Image src={displayImage} />
@@ -34,22 +33,21 @@ function Gallery({
         <div className={`${g.group} ${g.fullHeight}`}>
           <div className={`${g.stack} ${g.fullHeight} ${css.thumbnailWrapper}`}>
             {styles[selectedStyle].photos.map((photo, i) => (
-                <Thumbnail
-                  key={i}
-                  i={i}
-                  imgUrl={photo.thumbnail_url}
-                  selectedImage={selectedImage}
-                  setSelectedImage={setSelectedImage}
-                />
-              )
-            )}
+              <Thumbnail
+                key={photo.thumbnail_url}
+                i={i}
+                imgUrl={photo.thumbnail_url}
+                selectedImage={selectedImage}
+                setSelectedImage={setSelectedImage}
+              />
+            ))}
           </div>
           <div className={`${g.stack} ${css.controlsWrapper}`}>
-            <div className={css.fullscreen} >
+            <div className={css.fullscreen}>
               <CornersOut
                 size={32}
                 className={`${g.pointer} ${css.icon}`}
-                onClick={() => setIsFullScreen(prev => !prev)}
+                onClick={() => setIsFullScreen((prev) => !prev)}
               />
             </div>
             <div className={`${g.group} ${g.sb} ${css.arrows}`}>
@@ -68,7 +66,7 @@ function Gallery({
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 export default Gallery;

--- a/client/src/components/overview/components/Info.jsx
+++ b/client/src/components/overview/components/Info.jsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import { StyleSelector, Price, CartForm } from '../components';
-import { getSkus, getQtys } from '../lib/helpers.js';
+import React, { useState } from 'react';
+import axios from 'axios';
+import StyleSelector from './StyleSelector';
+import Price from './Price';
+import CartForm from './CartForm';
+import { getSkus, getQtys } from '../lib/helpers';
 import * as g from '../../global.module.css';
 import * as css from '../styles/info.module.css';
-import axios from 'axios';
 
 function Info({
   product,
@@ -12,18 +14,18 @@ function Info({
   setSelectedStyle,
   isFullScreen,
 }) {
-  const [sku, setSku] = useState(getSkus(styles[selectedStyle])[0]);
-  const [qty, setQty] = useState(getQtys(styles[selectedStyle], sku)[0]);
+  const [skuId, setSkuId] = useState(getSkus(styles[selectedStyle])[0]);
+  const [qty, setQty] = useState(getQtys(styles[selectedStyle], skuId)[0]);
 
   const postToCart = () => {
-    axios.post('/cart', {sku_id: parseInt(sku)})
-         .then(res => console.log('successfully added to cart', res))
-         .catch(err => console.log('failed to add to cart', err));
-  }
+    axios.post('/cart', { sku_id: parseInt(skuId, 10) })
+      .then((res) => console.debug('successfully added to cart', res))
+      .catch((err) => console.error('failed to add to cart', err));
+  };
   return (
     <div
       className={css.infoWrapper}
-      style={{display: isFullScreen ? 'none' : ''}}
+      style={{ display: isFullScreen ? 'none' : '' }}
     >
       <div className={`${g.stack} ${css.gap}`}>
         <div>stars</div>
@@ -34,22 +36,22 @@ function Info({
           styles={styles}
           selectedStyle={selectedStyle}
           setSelectedStyle={setSelectedStyle}
-          setSku={setSku}
+          setSkuId={setSkuId}
           setQty={setQty}
-          sku={sku}
+          skuId={skuId}
         />
         <CartForm
           styles={styles}
           selectedStyle={selectedStyle}
           postToCart={postToCart}
-          setSku={setSku}
+          setSkuId={setSkuId}
           setQty={setQty}
-          sku={sku}
+          skuId={skuId}
           qty={qty}
         />
       </div>
     </div>
-  )
+  );
 }
 
 export default Info;

--- a/client/src/components/overview/components/Price.jsx
+++ b/client/src/components/overview/components/Price.jsx
@@ -2,19 +2,21 @@ import React from 'react';
 import * as g from '../../global.module.css';
 import * as css from '../styles/price.module.css';
 
-function Price({styles, selectedStyle}) {
+function Price({ styles, selectedStyle }) {
   const onSale = styles[selectedStyle].sale_price !== null;
   return (
     <div className={`${g.group} ${css.gap}`}>
       <div style={{ textDecoration: onSale ? 'line-through' : '' }}>
-        {'$' + styles[selectedStyle].original_price}
+        {`$${styles[selectedStyle].original_price}`}
       </div>
-      {onSale &&
+      {onSale
+        && (
         <div className={css.red}>
-          {'$' + styles[selectedStyle].sale_price}
-        </div>}
+          {`$${styles[selectedStyle].sale_price}`}
+        </div>
+        )}
     </div>
-  )
+  );
 }
 
 export default Price;

--- a/client/src/components/overview/components/Select.jsx
+++ b/client/src/components/overview/components/Select.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import * as css from '../styles/select.module.css';
 
@@ -7,11 +7,11 @@ function Select({
   value = '',
   onChange,
   placeholder = 'Select...',
-  className = ''
+  className = '',
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectedOption = options.find(opt => opt.value === value);
+  const selectedOption = options.find((opt) => opt.value === value);
 
   const handleSelect = (val) => {
     onChange(val);
@@ -20,24 +20,29 @@ function Select({
 
   return (
     <div className={`${css.selectWrapper} ${className}`.trim()}>
-      <div
+      <button
+        type='button'
         className={css.selectDisplay}
-        onClick={() => setIsOpen(prev => !prev)}
+        onClick={() => setIsOpen((prev) => !prev)}
       >
         {selectedOption ? selectedOption.label : placeholder}
         <span className={css.arrow}>
           {isOpen ? <CaretUp size={20} /> : <CaretDown size={20} />}
         </span>
-      </div>
+      </button>
       {isOpen && (
         <ul className={css.selectList}>
           {options.map(({ value: optionValue, label }) => (
-            <li
-              key={optionValue}
-              className={`${css.selectOption} ${optionValue === value ? css.active : ''}`}
-              onClick={() => handleSelect(optionValue)}
-            >
-              {label}
+            <li key={optionValue} role='none'>
+              <button
+                type='button'
+                role='option'
+                aria-selected={optionValue === value}
+                className={`${css.selectOption} ${optionValue === value ? css.active : ''}`}
+                onClick={() => handleSelect(optionValue)}
+              >
+                {label}
+              </button>
             </li>
           ))}
         </ul>

--- a/client/src/components/overview/components/StyleSelector.jsx
+++ b/client/src/components/overview/components/StyleSelector.jsx
@@ -1,40 +1,47 @@
 import React from 'react';
-import Image from '../../shared/Image.jsx';
 import { Check } from '@phosphor-icons/react';
-import { getSkus, getQtys } from '../lib/helpers.js';
+import Image from '../../shared/Image';
+import { getSkus, getQtys } from '../lib/helpers';
 import * as g from '../../global.module.css';
 import * as css from '../styles/style_selector.module.css';
 
-function StyleSelector({styles, selectedStyle, setSelectedStyle, setSku, setQty, sku}) {
-
-  return(
+function StyleSelector({
+  styles, selectedStyle, setSelectedStyle, setSkuId, setQty, skuId,
+}) {
+  return (
     <>
       <div className={`${g.group} ${css.gap}`}>
-        <div><strong>STYLE {'>'}</strong></div>
+        <div>
+          <strong>
+            STYLE
+            {'>'}
+          </strong>
+        </div>
         <div>{styles[selectedStyle].name.toUpperCase()}</div>
       </div>
       <div className={css.grid}>
         {styles.map((style, i) => (
           <div key={style.style_id} className={css.circle}>
-            {selectedStyle === i &&
+            {selectedStyle === i
+              && (
               <div className={`${css.checkmark} ${g.center}`}>
-                <Check size={10}/>
+                <Check size={10} />
               </div>
-            }
+              )}
             <Image
               className={css.image}
               src={style.photos[0].thumbnail_url}
               onClick={() => {
-                setSku(getSkus(styles[i])[0])
-                setQty(getQtys(styles[selectedStyle], sku)[0])
-                setSelectedStyle(i)
+                setSkuId(getSkus(styles[i])[0]);
+                setQty(getQtys(styles[selectedStyle], skuId)[0]);
+                setSelectedStyle(i);
               }}
             />
           </div>
         ))}
       </div>
     </>
-  )
+  );
 }
 
 export default StyleSelector;

--- a/client/src/components/overview/components/Thumbnail.jsx
+++ b/client/src/components/overview/components/Thumbnail.jsx
@@ -1,20 +1,23 @@
 import React from 'react';
-import Image from '../../shared/Image.jsx';
+import Image from '../../shared/Image';
 import * as css from '../styles/thumbnail.module.css';
 
-function Thumbnail({imgUrl, selectedImage, setSelectedImage, i}) {
-  return(
-    <div
+function Thumbnail({
+  imgUrl, selectedImage, setSelectedImage, i,
+}) {
+  return (
+    <button
+      type='button'
       className={css.thumbnail}
       onClick={() => setSelectedImage(i)}
     >
-      <Image src={imgUrl}/>
+      <Image src={imgUrl} />
       <div
         className={css.indicator}
-        style={{backgroundColor: selectedImage === i ? 'brown' : 'transparent'}}
-        />
-    </div>
-  )
+        style={{ backgroundColor: selectedImage === i ? 'brown' : 'transparent' }}
+      />
+    </button>
+  );
 }
 
 export default Thumbnail;

--- a/client/src/components/overview/components/index.js
+++ b/client/src/components/overview/components/index.js
@@ -1,7 +1,0 @@
-export { default as Gallery } from './Gallery.jsx';
-export { default as Info } from './Info.jsx';
-export { default as Price } from './Price.jsx';
-export { default as CartForm } from './CartForm.jsx';
-export { default as StyleSelector } from './StyleSelector.jsx';
-export { default as Thumbnail } from './Thumbnail.jsx';
-export { default as Select } from './Select.jsx';

--- a/client/src/components/overview/lib/helpers.js
+++ b/client/src/components/overview/lib/helpers.js
@@ -3,7 +3,7 @@ function getSkus(style) {
 }
 
 function getQtys(style, sku) {
-  return Array.from({length: style.skus[sku].quantity}, (_, i) => '' + (i + 1));
+  return Array.from({ length: style.skus[sku].quantity }, (_, i) => `${i + 1}`);
 }
 
 export { getSkus, getQtys };

--- a/client/src/components/overview/styles/cart_form.module.css
+++ b/client/src/components/overview/styles/cart_form.module.css
@@ -1,7 +1,7 @@
 .gap {
-  gap: 10px
+  gap: 10px;
 }
 
 .fill {
-  flex: 1
+  flex: 1;
 }

--- a/client/src/components/overview/styles/select.module.css
+++ b/client/src/components/overview/styles/select.module.css
@@ -3,13 +3,13 @@
 }
 
 .selectDisplay {
-  border: 1px solid var(--color-border);
   padding: 8px 12px;
   background: var(--color-bg);
   cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
 }
 
 .arrow {
@@ -31,6 +31,9 @@
 .selectOption {
   padding: 8px 12px;
   cursor: pointer;
+  border: unset;
+  width: 100%;
+  text-align: left;
 }
 
 .selectOption:hover {

--- a/client/src/components/overview/styles/thumbnail.module.css
+++ b/client/src/components/overview/styles/thumbnail.module.css
@@ -1,10 +1,9 @@
 .thumbnail {
   background-color: white;
-  border: solid 1px var(--color-border);
   width: 100%;
   height: 50px;
-  cursor: pointer;
   position: relative;
+  padding: unset;
 }
 
 .indicator {

--- a/guidelines/before-you-push.md
+++ b/guidelines/before-you-push.md
@@ -26,6 +26,12 @@ npm run lint:fix
 
 > Note: Not all issues can be auto-fixed — you may still need to resolve some manually.
 
+Target a specific folder or file
+
+```bash
+npx eslint --ext .js,.jsx path/to/folder/or/file
+```
+
 ## 3. Final Touchups
 
 Remove any debugging logs (`console.log`)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "npx webpack",
     "start": "node server/index.js",
     "test": "npx jest",
-    "lint": "npx eslint client/src",
-    "lint:fix": "npx eslint client/src --fix"
+    "lint": "npx eslint --ext .js,.jsx client/src",
+    "lint:fix": "npx eslint --ext .js,.jsx client/src --fix"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,14 @@ module.exports = {
     filename: "bundle.js",
   },
   devtool: "source-map",
+  resolve: {
+    extensions: [".js", ".jsx"],
+  },
   module: {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /nodeModules/,
+        exclude: /node_modules/,
         use: {
           loader: "babel-loader",
         },


### PR DESCRIPTION
What I Changed
- linter only applies to files in the `client/src` folder
- removed prop-types rule
- ability to not have to type .jsx extension on component imports 